### PR TITLE
Swap build and revision numbers in PackageReader

### DIFF
--- a/Version/Version/Version.Plugin.WindowsPhone81/PackageReader.cs
+++ b/Version/Version/Version.Plugin.WindowsPhone81/PackageReader.cs
@@ -10,7 +10,7 @@ namespace Version.Plugin
             try
             {
                 var pv = Package.Current.Id.Version;
-                return string.Format("{0}.{1}.{2}.{3}", pv.Major, pv.Minor, pv.Revision, pv.Build);
+                return string.Format("{0}.{1}.{2}.{3}", pv.Major, pv.Minor, pv.Build, pv.Revision);
             }
             catch
             {


### PR DESCRIPTION
The version number for UWP apps is wrong - it has swapped build and revision numbers.